### PR TITLE
Fix regex patterns

### DIFF
--- a/ingest/buoy_humboldt/mapping.py
+++ b/ingest/buoy_humboldt/mapping.py
@@ -7,7 +7,7 @@ from . import Pipeline
 
 mapping: Dict["AnyStr@compile", IngestSpec] = {
     # Mapping for Raw Data -> Ingest
-    re.compile(r".*/buoy\.z05\.00\.\d{8}\.\d{8}\.zip"): IngestSpec(
+    re.compile(r".*/buoy\.z05\.00\.\d{8}\.\d{6}\.zip"): IngestSpec(
         pipeline=Pipeline,
         pipeline_config=expand("config/pipeline_config_buoy_humboldt.yml", __file__),
         storage_config=expand("config/storage_config_buoy_humboldt.yml", __file__),

--- a/ingest/buoy_morro/mapping.py
+++ b/ingest/buoy_morro/mapping.py
@@ -7,7 +7,7 @@ from . import Pipeline
 
 mapping: Dict["AnyStr@compile", IngestSpec] = {
     # Mapping for Raw Data -> Ingest
-    re.compile(r".*/buoy\.z06\.00\.\d{8}\.\d{8}\.zip"): IngestSpec(
+    re.compile(r".*/buoy\.z06\.00\.\d{8}\.\d{6}\.zip"): IngestSpec(
         pipeline=Pipeline,
         pipeline_config=expand("config/pipeline_config_buoy_morro.yml", __file__),
         storage_config=expand("config/storage_config_buoy_morro.yml", __file__),

--- a/ingest/imu_humboldt/mapping.py
+++ b/ingest/imu_humboldt/mapping.py
@@ -7,7 +7,7 @@ from . import Pipeline
 
 mapping: Dict["AnyStr@compile", IngestSpec] = {
     # Mapping for Raw Data -> Ingest
-    re.compile(r".*/buoy\.z05\.00\.\d{8}\.\d{8}\.imu\.bin"): IngestSpec(
+    re.compile(r".*/buoy\.z05\.00\.\d{8}\.\d{6}\.imu\.bin"): IngestSpec(
         pipeline=Pipeline,
         pipeline_config=expand("config/pipeline_config_imu_humboldt.yml", __file__),
         storage_config=expand("config/storage_config_imu_humboldt.yml", __file__),

--- a/ingest/imu_morro/mapping.py
+++ b/ingest/imu_morro/mapping.py
@@ -7,7 +7,7 @@ from . import Pipeline
 
 mapping: Dict["AnyStr@compile", IngestSpec] = {
     # Mapping for Raw Data -> Ingest
-    re.compile(r".*/buoy\.z06\.00\.\d{8}\.\d{8}\.imu\.bin"): IngestSpec(
+    re.compile(r".*/buoy\.z06\.00\.\d{8}\.\d{6}\.imu\.bin"): IngestSpec(
         pipeline=Pipeline,
         pipeline_config=expand("config/pipeline_config_imu_morro.yml", __file__),
         storage_config=expand("config/storage_config_imu_morro.yml", __file__),


### PR DESCRIPTION
Some of the regex patterns got the `time` part of the filename format wrong. The date and time formatting in filenames looks something like `20211217.000000`, but some of the regex patterns were using `\d{8}\.\d{8}` to match this section (which doesn't work). This PR fixes those instances by using `\d{8}\.\d{6}` instead.