### PR TITLE
Read lidar heights from the input file

### DIFF
--- a/pipelines/lidar/pipeline.py
+++ b/pipelines/lidar/pipeline.py
@@ -54,7 +54,7 @@ class Lidar(IngestPipeline):
         with self.storage.uploadable_dir(datastream) as tmp_dir:
 
             fig, ax = plt.subplots()
-            heights = [40, 90, 140, 200]
+            heights = dataset["height"].data[::3]
             for i, height in enumerate(heights):
                 velocity = ds.wind_speed.sel(height=height)
                 velocity.plot(


### PR DESCRIPTION
Previously the height dimension was hardcoded with values `[40, 60, 80, 90, 100, 120, 140, 160, 180, 200, 220, 240]`, but in April a few of these heights changed, causing the pipeline to break. Now these heights are read in from a header line in the input file.

The plotting function also had hardcoded values for heights to plot. These values matched every third height from the above list, so it will now grab every third height from the height dimension.